### PR TITLE
fix(pdf): address security review findings

### DIFF
--- a/src/libs/PdfExtractor.ts
+++ b/src/libs/PdfExtractor.ts
@@ -26,6 +26,11 @@ class TimeoutError extends Error {
 
 /**
  * Wraps a promise with a timeout.
+ * NOTE: This uses Promise.race which does not cancel the underlying operation.
+ * Timed-out PDF work may continue in background until natural completion.
+ * The unpdf library does not expose cancellation APIs.
+ * Under repeated slow/malformed inputs, this can accumulate CPU/memory pressure.
+ * Mitigations: page count limit, proxy.destroy() in finally block.
  * @param promise - Promise to wrap
  * @param timeoutMs - Timeout in milliseconds
  * @returns Promise that rejects with TimeoutError if timeout exceeded

--- a/src/libs/PdfValidator.test.ts
+++ b/src/libs/PdfValidator.test.ts
@@ -129,6 +129,39 @@ startxref
     expect(result.valid).toBe(true);
   });
 
+  it('rejects PDF with double EOF marker (polyglot bypass attempt)', async () => {
+    // Attack vector: %%EOF\n<script>...</script>\n%%EOF
+    // This tries to bypass polyglot detection by adding a second %%EOF at the end
+    const doubleEofPdf = `%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+196
+%%EOF
+<script>alert('xss')</script>
+%%EOF`;
+    const buffer = Buffer.from(doubleEofPdf);
+    const result = await validatePdfBuffer(buffer);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid data after PDF end marker');
+  });
+
   it('accepts Uint8Array input', async () => {
     const buffer = createValidPdfBuffer();
     const uint8Array = new Uint8Array(buffer);

--- a/src/libs/PdfValidator.ts
+++ b/src/libs/PdfValidator.ts
@@ -29,13 +29,13 @@ export type PdfValidationResult = {
 export async function validatePdfBuffer(
   buffer: Buffer | Uint8Array,
 ): Promise<PdfValidationResult> {
-  // Convert to Buffer if Uint8Array
-  const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
-
-  // Size limit check
-  if (buf.length > PDF_MAX_SIZE_BYTES) {
+  // Size limit check BEFORE buffer copy to avoid unnecessary allocation
+  if (buffer.length > PDF_MAX_SIZE_BYTES) {
     return { valid: false, error: 'PDF exceeds size limit' };
   }
+
+  // Convert to Buffer if Uint8Array (after size check)
+  const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
 
   // Minimum size for header
   if (buf.length < MIN_HEADER_BYTES) {
@@ -58,16 +58,18 @@ export async function validatePdfBuffer(
 
   // EOF marker check (polyglot attack prevention)
   // Search last 1KB for %%EOF marker and ensure it's the last non-whitespace content
+  // SECURITY: Use indexOf (first occurrence) not lastIndexOf to prevent double-EOF bypass
+  // Attack vector: %%EOF\n<script>...</script>\n%%EOF would pass with lastIndexOf
   const tailStart = Math.max(0, buf.length - PDF_EOF_SEARCH_BYTES);
   const tail = buf.subarray(tailStart).toString('ascii');
-  const eofIndex = tail.lastIndexOf('%%EOF');
+  const eofIndex = tail.indexOf('%%EOF');
 
   if (eofIndex === -1) {
     return { valid: false, error: 'Invalid PDF structure' };
   }
 
-  // Check that only whitespace follows %%EOF (polyglot prevention)
-  // Uses regex test to short-circuit on first non-whitespace, avoiding string allocation
+  // Check that only whitespace follows the FIRST %%EOF (polyglot prevention)
+  // This catches both trailing data AND duplicate %%EOF markers
   const afterEof = tail.slice(eofIndex + 5); // 5 = length of '%%EOF'
   if (/\S/.test(afterEof)) {
     return { valid: false, error: 'Invalid data after PDF end marker' };


### PR DESCRIPTION
## Summary

Follow-up security fixes identified in review of PR #6:

- **P1 CRITICAL**: Fix double-`%%EOF` bypass — use `indexOf` (first occurrence) instead of `lastIndexOf` so an input like `%%EOF\n<script>\n%%EOF` is correctly rejected
- **P2**: Check buffer size before `Buffer.from()` copy to avoid unnecessary allocation
- **P2**: Document timeout limitation in `withTimeout` JSDoc

## Test plan

- [ ] Run `pnpm test src/libs/PdfValidator.test.ts` — all tests pass including new double-EOF bypass test
- [ ] Run `pnpm test src/libs/PdfExtractor.test.ts` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)